### PR TITLE
More comprehensive and weighted css reset

### DIFF
--- a/var_masterpiece_extension/css/var_dump.css
+++ b/var_masterpiece_extension/css/var_dump.css
@@ -1,96 +1,129 @@
-.VAR_DUMP-DEADBEEF {
+.VAR_DUMP-DEADBEEF, .VAR_DUMP-DEADBEEF * {
   font-family: monospace;
   font-size: 18px;
-  color: black; }
-  .VAR_DUMP-DEADBEEF #var_dump {
-    font-size: 16px;
-    white-space: pre-wrap;
-    padding-left: 20px; }
-    .VAR_DUMP-DEADBEEF #var_dump .prop {
-      font-weight: bold; }
-    .VAR_DUMP-DEADBEEF #var_dump .null {
-      color: red; }
-    .VAR_DUMP-DEADBEEF #var_dump .bool {
-      color: purple; }
-    .VAR_DUMP-DEADBEEF #var_dump .int {
-      color: blue; }
-    .VAR_DUMP-DEADBEEF #var_dump .float {
-      color: orange; }
-    .VAR_DUMP-DEADBEEF #var_dump .string {
-      color: green;
-      white-space: pre-wrap; }
-    .VAR_DUMP-DEADBEEF #var_dump .key {
-      float: left;
-      font-weight: bold; }
-    .VAR_DUMP-DEADBEEF #var_dump #root {
-      margin: 0 0 0 0; }
-    .VAR_DUMP-DEADBEEF #var_dump ul {
-      margin-left: 40px;
-      list-style: none;
-      padding: 0; }
-    .VAR_DUMP-DEADBEEF #var_dump .openClose {
-      position: relative; }
-      .VAR_DUMP-DEADBEEF #var_dump .openClose .openCloseIcon {
-        position: absolute;
-        top: 0;
-        left: -20px;
-        display: inline-block;
-        cursor: pointer;
-        transition: transform 0.3s ease; }
-        .VAR_DUMP-DEADBEEF #var_dump .openClose .openCloseIcon.closed {
-          transform: rotate(180deg); }
-    .VAR_DUMP-DEADBEEF #var_dump .hide {
-      display: none; }
-    .VAR_DUMP-DEADBEEF #var_dump .clear {
-      clear: both; }
-    .VAR_DUMP-DEADBEEF #var_dump .all {
-      background-color: rgba(146, 116, 51, 0.1);
-      width: 250px; }
-    .VAR_DUMP-DEADBEEF #var_dump .closeall {
-      float: right; }
-    .VAR_DUMP-DEADBEEF #var_dump .closeall:hover {
-      text-decoration: underline;
-      cursor: pointer; }
-    .VAR_DUMP-DEADBEEF #var_dump .openall:hover {
-      text-decoration: underline;
-      cursor: pointer; }
-  .VAR_DUMP-DEADBEEF .var_dump_modal {
-    max-height: 80%;
-    width: 80%;
-    position: fixed;
-    box-shadow: 0 0 10px #888;
-    top: 10%;
-    left: 10%;
-    padding: 5%;
-    background-color: white;
-    opacity: .95;
-    border-radius: 2px;
-    box-sizing: border-box;
-    overflow: scroll;
-    z-index: 50; }
-    .VAR_DUMP-DEADBEEF .var_dump_modal #header {
-      height: 25px;
-      width: 100%;
-      border-bottom: 2px solid #BC2D09;
-      margin-bottom: 10px; }
-      .VAR_DUMP-DEADBEEF .var_dump_modal #header #expandAll,
-      .VAR_DUMP-DEADBEEF .var_dump_modal #header #collapseAll {
-        cursor: pointer;
-        padding-right: 20px;
-        float: left; }
-      .VAR_DUMP-DEADBEEF .var_dump_modal #header .closeModal {
-        cursor: pointer;
-        float: right; }
-    .VAR_DUMP-DEADBEEF .var_dump_modal .failedMessage {
-      padding: 5px;
-      background-color: #BC2D09;
-      border-radius: 2px;
-      color: white;
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
-  .VAR_DUMP-DEADBEEF .svgIcon img,
-  .VAR_DUMP-DEADBEEF img.svgIcon {
-    height: 15px; }
-  .VAR_DUMP-DEADBEEF .rotate180 {
-    transform: rotate(180deg); }
+  color: black;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+  line-height: 1;
+}
+.VAR_DUMP-DEADBEEF #var_dump {
+  font-size: 16px;
+  white-space: pre-wrap;
+  padding-left: 20px;
+}
+.VAR_DUMP-DEADBEEF #var_dump .prop {
+  font-weight: bold;
+}
+.VAR_DUMP-DEADBEEF #var_dump .null {
+  color: red;
+}
+.VAR_DUMP-DEADBEEF #var_dump .bool {
+  color: purple;
+}
+.VAR_DUMP-DEADBEEF #var_dump .int {
+  color: blue;
+}
+.VAR_DUMP-DEADBEEF #var_dump .float {
+  color: orange;
+}
+.VAR_DUMP-DEADBEEF #var_dump .string {
+  color: green;
+  white-space: pre-wrap;
+}
+.VAR_DUMP-DEADBEEF #var_dump .key {
+  float: left;
+  font-weight: bold;
+}
+.VAR_DUMP-DEADBEEF #var_dump #root {
+  margin: 0 0 0 0;
+}
+.VAR_DUMP-DEADBEEF #var_dump ul {
+  margin-left: 40px;
+  list-style: none;
+  padding: 0;
+}
+.VAR_DUMP-DEADBEEF #var_dump .openClose {
+  position: relative;
+}
+.VAR_DUMP-DEADBEEF #var_dump .openClose .openCloseIcon {
+  position: absolute;
+  top: 0;
+  left: -20px;
+  display: inline-block;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+.VAR_DUMP-DEADBEEF #var_dump .openClose .openCloseIcon.closed {
+  transform: rotate(180deg);
+}
+.VAR_DUMP-DEADBEEF #var_dump .hide {
+  display: none;
+}
+.VAR_DUMP-DEADBEEF #var_dump .clear {
+  clear: both;
+}
+.VAR_DUMP-DEADBEEF #var_dump .all {
+  background-color: rgba(146, 116, 51, 0.1);
+  width: 250px;
+}
+.VAR_DUMP-DEADBEEF #var_dump .closeall {
+  float: right;
+}
+.VAR_DUMP-DEADBEEF #var_dump .closeall:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+.VAR_DUMP-DEADBEEF #var_dump .openall:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+.VAR_DUMP-DEADBEEF .var_dump_modal {
+  max-height: 80%;
+  width: 80%;
+  position: fixed;
+  box-shadow: 0 0 10px #888;
+  top: 10%;
+  left: 10%;
+  padding: 5%;
+  background-color: white;
+  opacity: .95;
+  border-radius: 2px;
+  box-sizing: border-box;
+  overflow: scroll;
+  z-index: 50;
+}
+.VAR_DUMP-DEADBEEF .var_dump_modal #header {
+  height: 25px;
+  width: 100%;
+  border-bottom: 2px solid #BC2D09;
+  margin-bottom: 10px;
+}
+.VAR_DUMP-DEADBEEF .var_dump_modal #header #expandAll,
+.VAR_DUMP-DEADBEEF .var_dump_modal #header #collapseAll {
+  cursor: pointer;
+  padding-right: 20px;
+  float: left;
+}
+.VAR_DUMP-DEADBEEF .var_dump_modal #header .closeModal {
+  cursor: pointer;
+  float: right;
+}
+.VAR_DUMP-DEADBEEF .var_dump_modal .failedMessage {
+  padding: 5px;
+  background-color: #BC2D09;
+  border-radius: 2px;
+  color: white;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+.VAR_DUMP-DEADBEEF .svgIcon img,
+.VAR_DUMP-DEADBEEF img.svgIcon {
+  height: 15px;
+}
+.VAR_DUMP-DEADBEEF .rotate180 {
+  transform: rotate(180deg);
+}
 
 /*# sourceMappingURL=var_dump.css.map */

--- a/var_masterpiece_extension/css/var_dump.scss
+++ b/var_masterpiece_extension/css/var_dump.scss
@@ -1,7 +1,19 @@
-.VAR_DUMP-DEADBEEF { //to avoid accidental styling collisions
-  	font-family: monospace;
-  	font-size:18px;
-  	color: black; //add default color in case the page being dumped provides one.
+.VAR_DUMP-DEADBEEF { 
+	//A basic CSS reset to avoid any styling collisions
+	font-family: monospace;
+	font-size:18px;
+	color: black; 
+	padding: 0;
+	margin: 0;
+	border: 0;
+	font-size: 100%;
+	vertical-align: baseline;
+	line-height: 1;
+	
+	* { //Apply the CSS Reset to all elements to give this stylesheet more wieght than any existing stylesheets
+		@extend .VAR_DUMP-DEADBEEF;
+	}
+  		
 
 	#var_dump { //the var dump output
 		font-size: 16px;
@@ -141,7 +153,7 @@
 	//utility
 	.svgIcon img,
 	img.svgIcon {
-		height: 15px
+		height: 15px;
 	}
 
 	.rotate180 {


### PR DESCRIPTION
Due to multiple instances of styling conflicts in web pages, I created a much more comprehensive css reset that resets things like margins, padding, borders etc. 

I also had the reset applied to all child elements of the main VAR_DUMP-DEADBEEF class so that this stylesheet would have more weight than a stylesheet trying to style a generic html element.

This should stop any and all outside stylesheets from messing with the plugin styling. 